### PR TITLE
IAsyncEnumerable support

### DIFF
--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -134,12 +134,7 @@
 
 	<Target Name="Test" />
 
-	<Target Name="UpdatePackageMetadata"
-          BeforeTargets="PrepareForBuild;GetAssemblyVersion;GenerateNuspec;Pack"
-          DependsOnTargets="InitializeSourceControlInformation"
-          Condition="'$(SourceControlInformationFeatureSupported)' And
-                     '$(RepositoryUrl)' != '' And 
-                     '$(SourceRevisionId)' != ''">
+	<Target Name="UpdatePackageMetadata" BeforeTargets="PrepareForBuild;GetAssemblyVersion;GenerateNuspec;Pack" DependsOnTargets="InitializeSourceControlInformation" Condition="'$(SourceControlInformationFeatureSupported)' And&#xD;&#xA;                     '$(RepositoryUrl)' != '' And &#xD;&#xA;                     '$(SourceRevisionId)' != ''">
 		<PropertyGroup>
 			<Description>$(Description)
 

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -6,7 +6,7 @@
 	<Import Project="$(BuildDirectory)SourceLink.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net45;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net45;net461;netstandard2.0;netstandard2.1</TargetFrameworks>
 		<AssemblyName>Moq</AssemblyName>
 		<DebugSymbols>True</DebugSymbols>
 		<DebugType>embedded</DebugType>
@@ -20,10 +20,14 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-		<DefineConstants>$(DefineConstants);FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS;FEATURE_ASYNC_ENUMERABLE</DefineConstants>
+		<DefineConstants>$(DefineConstants);FEATURE_ASYNC_ENUMERABLE;FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<DefineConstants>$(DefineConstants);FEATURE_ASYNC_ENUMERABLE</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
 		<DefineConstants>$(DefineConstants);FEATURE_ASYNC_ENUMERABLE</DefineConstants>
 	</PropertyGroup>
 
@@ -53,8 +57,7 @@
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 		<PackageReference Include="TypeNameFormatter.Sources" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' != 'net45'">
+	<ItemGroup Condition=" $([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants)', 'FEATURE_ASYNC_ENUMERABLE'))">
 		<PackageReference Include="System.Linq.Async" Version="4.0.0" />
 	</ItemGroup>
 

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -20,7 +20,11 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-		<DefineConstants>$(DefineConstants);FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS</DefineConstants>
+		<DefineConstants>$(DefineConstants);FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS;FEATURE_ASYNC_ENUMERABLE</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<DefineConstants>$(DefineConstants);FEATURE_ASYNC_ENUMERABLE</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -48,6 +52,10 @@
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 		<PackageReference Include="TypeNameFormatter.Sources" Version="1.0.0" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' != 'net45'">
+		<PackageReference Include="System.Linq.Async" Version="4.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Moq/ReturnsExtensions.Generated.cs
+++ b/src/Moq/ReturnsExtensions.Generated.cs
@@ -8,6 +8,11 @@ using System.Threading.Tasks;
 using Moq.Language;
 using Moq.Language.Flow;
 
+#if FEATURE_ASYNC_ENUMERABLE
+using System.Collections.Generic;
+using System.Linq;
+#endif
+
 namespace Moq
 {
 	/// <summary>
@@ -396,5 +401,146 @@ namespace Moq
 		{
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)));
 		}
+
+#if FEATURE_ASYNC_ENUMERABLE
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <typeparam name="T">Type of the function parameter.</typeparam>
+		/// <typeparam name="TMock">Mocked type.</typeparam>
+		/// <typeparam name="TResult">Type of the return value.</typeparam>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T t) => valueFunction(t).ToAsyncEnumerable());
+		}
+				/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2) => valueFunction(t1, t2).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3) => valueFunction(t1, t2, t3).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4) => valueFunction(t1, t2, t3, t4).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, T5, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) => valueFunction(t1, t2, t3, t4, t5).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) => valueFunction(t1, t2, t3, t4, t5, t6).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) => valueFunction(t1, t2, t3, t4, t5, t6, t7).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) => valueFunction(t1, t2, t3, t4, t5, t6, t7, t8).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) => valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10) => valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11) => valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12) => valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13) => valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14) => valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14).ToAsyncEnumerable());
+		}
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15) => valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15).ToAsyncEnumerable());
+		}
+#endif
 	}
 }

--- a/src/Moq/ReturnsExtensions.cs
+++ b/src/Moq/ReturnsExtensions.cs
@@ -105,12 +105,12 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return values.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<IEnumerable<TResult>> valueFunction) where TMock : class
 		{
-			if (IsNullResult(valueFunction, typeof(TResult)))
+			if (IsNullResult(valueFunction, typeof(IEnumerable<TResult>)))
 			{
 				return mock.ReturnsAsync(() => default);
 			}
 
-			return mock.Returns(() => valueFunction().ToAsyncEnumerable());
+			return mock.Returns(() => valueFunction()?.ToAsyncEnumerable());
 		}
 #endif
 

--- a/src/Moq/ReturnsExtensions.cs
+++ b/src/Moq/ReturnsExtensions.cs
@@ -217,7 +217,7 @@ namespace Moq
 		/// Allows to specify the delayed return value of an asynchronous enumerable method.
 		/// </summary>
 		public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock,
-			TResult value, TimeSpan delay) where TMock : class
+			IEnumerable<TResult> value, TimeSpan delay) where TMock : class
 		{
 			return DelayedResult(mock, value, delay);
 		}
@@ -250,7 +250,7 @@ namespace Moq
 		/// Allows to specify the delayed return value of an asynchronous enumerable method.
 		/// </summary>
 		public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock,
-			TResult value, TimeSpan minDelay, TimeSpan maxDelay) where TMock : class
+			IEnumerable<TResult> value, TimeSpan minDelay, TimeSpan maxDelay) where TMock : class
 		{
 			var delay = GetDelay(minDelay, maxDelay, Random);
 
@@ -294,7 +294,7 @@ namespace Moq
 		/// <para>Use the <see cref="Random"/> argument to pass in (seeded) random generators used across your unit test.</para>
 		/// </summary>
 		public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock,
-			TResult value, TimeSpan minDelay, TimeSpan maxDelay, Random random) where TMock : class
+			IEnumerable<TResult> value, TimeSpan minDelay, TimeSpan maxDelay, Random random) where TMock : class
 		{
 			if (random == null)
 				throw new ArgumentNullException(nameof(random));
@@ -397,6 +397,23 @@ namespace Moq
 
 			return DelayedException(mock, exception, delay);
 		}
+
+#if FEATURE_ASYNC_ENUMERABLE
+		/// <summary>
+		/// <para>Allows to specify the exception thrown by an asynchronous method.</para> 
+		/// <para>Use the <see cref="Random"/> argument to pass in (seeded) random generators used across your unit test.</para>
+		/// </summary>
+		public static IReturnsResult<TMock> ThrowsAsync<TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock,
+			Exception exception, TimeSpan minDelay, TimeSpan maxDelay, Random random) where TMock : class
+		{
+			if (random == null)
+				throw new ArgumentNullException(nameof(random));
+
+			var delay = GetDelay(minDelay, maxDelay, random);
+
+			return DelayedException(mock, exception, delay);
+		}
+#endif
 
 		internal static bool IsNullResult(Delegate valueFunction, Type resultType)
 		{
@@ -447,7 +464,7 @@ namespace Moq
 
 #if FEATURE_ASYNC_ENUMERABLE
 		private static IReturnsResult<TMock> DelayedResult<TMock, TResult>(IReturns<TMock, IAsyncEnumerable<TResult>> mock,
-			TResult value, TimeSpan delay)
+			IEnumerable<TResult> value, TimeSpan delay)
 			where TMock : class
 		{
 			Guard.Positive(delay);

--- a/src/Moq/ReturnsExtensions.cs
+++ b/src/Moq/ReturnsExtensions.cs
@@ -469,11 +469,16 @@ namespace Moq
 		{
 			Guard.Positive(delay);
 
-			return mock.Returns(() =>
+			async IAsyncEnumerable<TResult> DelayThenContinue()
 			{
-				Task.Delay(delay).ContinueWith(t => value);
-				return AsyncEnumerable.Empty<TResult>();
-			});
+				await Task.Delay(delay);
+				foreach (var item in value)
+				{
+					yield return item;
+				}
+			}
+
+			return mock.Returns(DelayThenContinue);
 		}
 
 #endif

--- a/src/Moq/ReturnsExtensions.tt
+++ b/src/Moq/ReturnsExtensions.tt
@@ -12,6 +12,11 @@ using System.Threading.Tasks;
 using Moq.Language;
 using Moq.Language.Flow;
 
+#if FEATURE_ASYNC_ENUMERABLE
+using System.Collections.Generic;
+using System.Linq;
+#endif
+
 namespace Moq
 {
 	/// <summary>
@@ -119,5 +124,52 @@ namespace Moq
 <#
 		}
 		#>
+
+#if FEATURE_ASYNC_ENUMERABLE
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <typeparam name="T">Type of the function parameter.</typeparam>
+		/// <typeparam name="TMock">Mocked type.</typeparam>
+		/// <typeparam name="TResult">Type of the return value.</typeparam>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T, TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<T, IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((T t) => valueFunction(t).ToAsyncEnumerable());
+		}
+		<#
+		for (var argumentCount = 2; argumentCount <= 15; ++argumentCount)
+		{ #>
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<<#
+			for (var i = 1; i <= argumentCount; ++i)
+			{
+				#>T<#=i#>, <#
+			}#>TMock, TResult>(this IReturns<TMock, IAsyncEnumerable<TResult>> mock, Func<<#
+			for (var i = 1; i <= argumentCount; ++i)
+			{
+				#>T<#=i#>, <#
+			}#>IEnumerable<TResult>> valueFunction) where TMock : class
+		{
+			return mock.Returns((<#
+			for (var i = 1; i <= argumentCount; ++i)
+			{ #>T<#=i#> t<#=i#><#
+				if(i != argumentCount) {#>, <#}#><#
+			}#>) => valueFunction(<#
+			for (var i = 1; i <= argumentCount; ++i)
+			{
+				#>t<#=i#><#
+				if (i != argumentCount) { #>, <#}#><#
+			}#>).ToAsyncEnumerable());
+		}
+<#
+		}
+		#>
+#endif
 	}
 }

--- a/src/Moq/SequenceExtensions.cs
+++ b/src/Moq/SequenceExtensions.cs
@@ -56,17 +56,17 @@ namespace Moq
 		/// <summary>
 		/// Return a sequence of tasks, once per call.
 		/// </summary>
-		public static ISetupSequentialResult<IAsyncEnumerable<TResult>> ReturnsAsync<TResult>(this ISetupSequentialResult<IAsyncEnumerable<TResult>> setup, TResult value)
+		public static ISetupSequentialResult<IAsyncEnumerable<TResult>> ReturnsAsync<TResult>(this ISetupSequentialResult<IAsyncEnumerable<TResult>> setup, IEnumerable<TResult> value)
 		{
-			return setup.Returns(() => new[] { value }.ToAsyncEnumerable());
+			return setup.Returns(() => value.ToAsyncEnumerable());
 		}
 
 		/// <summary>
 		/// Return a sequence of tasks, once per call.
 		/// </summary>
-		public static ISetupSequentialResult<IAsyncEnumerable<TResult>> ReturnsAsync<TResult>(this ISetupSequentialResult<IAsyncEnumerable<TResult>> setup, Func<TResult> valueFunction)
+		public static ISetupSequentialResult<IAsyncEnumerable<TResult>> ReturnsAsync<TResult>(this ISetupSequentialResult<IAsyncEnumerable<TResult>> setup, Func<IEnumerable<TResult>> valueFunction)
 		{
-			return setup.Returns(() => new[] { valueFunction() }.ToAsyncEnumerable());
+			return setup.Returns(() => valueFunction().ToAsyncEnumerable());
 		}
 
 #endif

--- a/src/Moq/SequenceExtensions.cs
+++ b/src/Moq/SequenceExtensions.cs
@@ -7,6 +7,11 @@ using System.Threading.Tasks;
 
 using Moq.Language;
 
+#if FEATURE_ASYNC_ENUMERABLE
+using System.Collections.Generic;
+using System.Linq;
+#endif
+
 namespace Moq
 {
 	/// <summary>
@@ -46,6 +51,25 @@ namespace Moq
 		{
 			return setup.Returns(() => new ValueTask<TResult>(valueFunction()));
 		}
+
+#if FEATURE_ASYNC_ENUMERABLE
+		/// <summary>
+		/// Return a sequence of tasks, once per call.
+		/// </summary>
+		public static ISetupSequentialResult<IAsyncEnumerable<TResult>> ReturnsAsync<TResult>(this ISetupSequentialResult<IAsyncEnumerable<TResult>> setup, TResult value)
+		{
+			return setup.Returns(() => new[] { value }.ToAsyncEnumerable());
+		}
+
+		/// <summary>
+		/// Return a sequence of tasks, once per call.
+		/// </summary>
+		public static ISetupSequentialResult<IAsyncEnumerable<TResult>> ReturnsAsync<TResult>(this ISetupSequentialResult<IAsyncEnumerable<TResult>> setup, Func<TResult> valueFunction)
+		{
+			return setup.Returns(() => new[] { valueFunction() }.ToAsyncEnumerable());
+		}
+
+#endif
 
 		/// <summary>
 		/// Return a sequence of tasks, once per call.
@@ -88,6 +112,21 @@ namespace Moq
 				return new ValueTask<TResult>(tcs.Task);
 			});
 		}
+
+#if FEATURE_ASYNC_ENUMERABLE
+		/// <summary>
+		/// Throws a sequence of exceptions, once per call.
+		/// </summary>
+		public static ISetupSequentialResult<IAsyncEnumerable<TResult>> ThrowsAsync<TResult>(this ISetupSequentialResult<IAsyncEnumerable<TResult>> setup, Exception exception)
+		{
+			return setup.Returns(() =>
+			{
+				var tcs = new TaskCompletionSource<TResult>();
+				tcs.SetException(exception);
+				return AsyncEnumerable.Empty<TResult>();
+			});
+		}
+#endif
 
 		/// <summary>
 		/// Throws a sequence of exceptions, once per call.

--- a/src/Moq/SequenceExtensions.cs
+++ b/src/Moq/SequenceExtensions.cs
@@ -123,7 +123,7 @@ namespace Moq
 			{
 				var tcs = new TaskCompletionSource<TResult>();
 				tcs.SetException(exception);
-				return AsyncEnumerable.Empty<TResult>();
+				return tcs.Task.ToAsyncEnumerable();
 			});
 		}
 #endif

--- a/tests/Moq.Tests/GeneratedReturnsExtensionsFixture.cs
+++ b/tests/Moq.Tests/GeneratedReturnsExtensionsFixture.cs
@@ -7,6 +7,10 @@ using System.Threading.Tasks;
 
 using Xunit;
 
+#if FEATURE_ASYNC_ENUMERABLE
+using System.Collections.Generic;
+#endif
+
 namespace Moq.Tests
 {
 	public class GeneratedReturnsExtensionsFixture
@@ -16,6 +20,12 @@ namespace Moq.Tests
 			Task<int> WithSingleParameterAsync(int parameter);
 			Task<string> WithMultiParameterAsync(string firstParameter, string secondParameter);
 			Task<DateTime> WithParamsAsync(params DateTime[] dateTimes);
+
+#if FEATURE_ASYNC_ENUMERABLE
+			IAsyncEnumerable<int> AsyncEnumerableWithSingleParameterAsync(int parameter);
+			IAsyncEnumerable<string> AsyncEnumerableWithMultiParameterAsync(string firstParameter, string secondParameter);
+			IAsyncEnumerable<DateTime> AsyncEnumerableWithParamsAsync(params DateTime[] dateTimes);
+#endif
 		}
 
 		[Fact]
@@ -95,5 +105,89 @@ namespace Moq.Tests
 
 			Assert.NotEqual(firstEvaluationResult, secondEvaluationResult);
 		}
+
+#if FEATURE_ASYNC_ENUMERABLE
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_onSingleParameter_ParameterUsedForCalculationOfTheResult()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			mock.Setup(x => x.AsyncEnumerableWithSingleParameterAsync(It.IsAny<int>())).ReturnsAsync((int x) => new[] { x * x });
+
+			int[] evaluationResult = mock.Object.AsyncEnumerableWithSingleParameterAsync(2).ToArrayAsync().Result;
+
+			Assert.Equal(new[] { 4 }, evaluationResult);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_onSingleParameter_LazyEvaluationOfTheResult()
+		{
+			int coefficient = 5;
+			var mock = new Mock<IAsyncInterface>();
+			mock.Setup(x => x.AsyncEnumerableWithSingleParameterAsync(It.IsAny<int>())).ReturnsAsync((int x) => new[] { x * coefficient });
+
+			int[] firstEvaluationResult = mock.Object.AsyncEnumerableWithSingleParameterAsync(2).ToArrayAsync().Result;
+
+			coefficient = 10;
+			int[] secondEvaluationResult = mock.Object.AsyncEnumerableWithSingleParameterAsync(2).ToArrayAsync().Result;
+
+			Assert.NotEqual(firstEvaluationResult, secondEvaluationResult);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_onMultiParameter_ParametersUsedForCalculationOfTheResult()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			mock.Setup(x => x.AsyncEnumerableWithMultiParameterAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((string first, string second) => new[] { first + second });
+
+			string[] evaluationResult = mock.Object.AsyncEnumerableWithMultiParameterAsync("Moq", "4").ToArrayAsync().Result;
+
+			Assert.Equal(new[] { "Moq4" }, evaluationResult);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_onMultiParameter_LazyEvaluationOfTheResult()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			mock.Setup(x => x.AsyncEnumerableWithMultiParameterAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((string first, string second) => new[] { first + second });
+
+			string[] firstEvaluationResult = mock.Object.AsyncEnumerableWithMultiParameterAsync("Moq", "4").ToArrayAsync().Result;
+			string[] secondEvaluationResult = mock.Object.AsyncEnumerableWithMultiParameterAsync("Moq", "4").ToArrayAsync().Result;
+
+			Assert.NotSame(firstEvaluationResult, secondEvaluationResult);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_onParams_AllParametersUsedForCalculationOfTheResult()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			mock.Setup(x => x.AsyncEnumerableWithParamsAsync(It.IsAny<DateTime[]>()))
+				.ReturnsAsync((DateTime[] dateTimes) => dateTimes);
+
+			var now = DateTime.Now;
+
+			DateTime[] evaluationResult = mock.Object.AsyncEnumerableWithParamsAsync(DateTime.MinValue, now, DateTime.MaxValue).ToArrayAsync().Result;
+
+			Assert.Equal(new[] { DateTime.MinValue, now, DateTime.MaxValue }, evaluationResult);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_onParams_LazyEvaluationOfTheResult()
+		{
+			DateTime comparedDateTime = DateTime.MinValue;
+			var mock = new Mock<IAsyncInterface>();
+			mock.Setup(x => x.AsyncEnumerableWithParamsAsync(It.IsAny<DateTime[]>()))
+				.ReturnsAsync((DateTime[] dateTimes) => dateTimes.Concat(new[] { comparedDateTime }));
+
+			DateTime now = DateTime.Now;
+			DateTime[] firstEvaluationResult = mock.Object.AsyncEnumerableWithParamsAsync(DateTime.MinValue, now).ToArrayAsync().Result;
+
+			comparedDateTime = DateTime.MaxValue;
+			DateTime[] secondEvaluationResult = mock.Object.AsyncEnumerableWithParamsAsync(DateTime.MinValue, now).ToArrayAsync().Result;
+
+			Assert.NotEqual(firstEvaluationResult, secondEvaluationResult);
+		}
+
+#endif
 	}
 }

--- a/tests/Moq.Tests/Moq.Tests.csproj
+++ b/tests/Moq.Tests/Moq.Tests.csproj
@@ -15,10 +15,10 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
-		<DefineConstants>$(DefineConstants);FEATURE_DYNAMICPROXY_SERIALIZABLE_PROXIES;FEATURE_EF;FEATURE_SYSTEM_WEB;FEATURE_SYSTEM_WINDOWS_FORMS</DefineConstants>
+		<DefineConstants>$(DefineConstants);FEATURE_ASYNC_ENUMERABLE;FEATURE_DYNAMICPROXY_SERIALIZABLE_PROXIES;FEATURE_EF;FEATURE_SYSTEM_WEB;FEATURE_SYSTEM_WINDOWS_FORMS</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-		<DefineConstants>$(DefineConstants);FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS</DefineConstants>
+		<DefineConstants>$(DefineConstants);FEATURE_ASYNC_ENUMERABLE;FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -33,6 +33,9 @@
 		<Reference Include="Moq.Tests.ComTypes">
 			<HintPath>..\Moq.Tests.ComTypes\Moq.Tests.ComTypes.dll</HintPath>
 		</Reference>
+	</ItemGroup>
+	<ItemGroup Condition=" $([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants)', 'FEATURE_ASYNC_ENUMERABLE'))">
+		<PackageReference Include="System.Linq.Async" Version="4.0.0" />
 	</ItemGroup>
 	<ItemGroup Condition=" $([System.Text.RegularExpressions.Regex]::IsMatch('$(DefineConstants)', 'FEATURE_EF'))">
 		<PackageReference Include="EntityFramework" Version="6.2.0" />

--- a/tests/Moq.Tests/ReturnsExtensionsFixture.cs
+++ b/tests/Moq.Tests/ReturnsExtensionsFixture.cs
@@ -978,7 +978,7 @@ namespace Moq.Tests
 			var enumerable = mock.Object.RefParameterRefReturnType("Param1");
 			var task = enumerable.ToArrayAsync();
 
-			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(enumerable);
 			Assert.True(task.IsCompleted);
 			Assert.Equal(new[] { "TestString" }, task.Result);
 		}
@@ -1138,7 +1138,7 @@ namespace Moq.Tests
 
 			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(firstEnumerable);
 			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(secondEnumerable);
-			Assert.NotEqual(firstTask.Result, secondTask.Result);
+			Assert.NotSame(firstTask.Result, secondTask.Result);
 		}
 
 		[Fact]
@@ -1267,11 +1267,11 @@ namespace Moq.Tests
 		[Fact]
 		public async Task AsyncEnumerableReturnsAsyncWithDelayReturnsValue()
 		{
-			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>(MockBehavior.Strict);
 			mock.Setup(x => x.RefParameterValueReturnType("test")).ReturnsAsync(new[] { 5 }, TimeSpan.FromMilliseconds(1));
 
-			var task = mock.Object.RefParameterValueReturnType("test");
-			var value = await Assert.IsAssignableFrom<IAsyncEnumerable<int>>(task).ToArrayAsync();
+			var enumerable = mock.Object.RefParameterValueReturnType("test");
+			var value = await Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable).ToArrayAsync();
 
 			Assert.Equal(new[] { 5 }, value);
 		}

--- a/tests/Moq.Tests/ReturnsExtensionsFixture.cs
+++ b/tests/Moq.Tests/ReturnsExtensionsFixture.cs
@@ -1267,7 +1267,7 @@ namespace Moq.Tests
 		[Fact]
 		public async Task AsyncEnumerableReturnsAsyncWithDelayReturnsValue()
 		{
-			var mock = new Mock<IAsyncEnumerableAsyncInterface>(MockBehavior.Strict);
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
 			mock.Setup(x => x.RefParameterValueReturnType("test")).ReturnsAsync(new[] { 5 }, TimeSpan.FromMilliseconds(1));
 
 			var enumerable = mock.Object.RefParameterValueReturnType("test");

--- a/tests/Moq.Tests/ReturnsExtensionsFixture.cs
+++ b/tests/Moq.Tests/ReturnsExtensionsFixture.cs
@@ -1452,5 +1452,40 @@ namespace Moq.Tests
 
 			Assert.Null(result);
 		}
+
+#if FEATURE_ASYNC_ENUMERABLE
+		[Fact]
+		public void No_parameters_object_return_type__ReturnsAsync_null__returns_null_AsyncEnumerable()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(m => m.NoParametersObjectReturnType()).ReturnsAsync((IEnumerable<object>) null);
+
+			var result = mock.Object.NoParametersObjectReturnType();
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public void One_parameter_object_return_type__ReturnsAsync_null__returns_null_AsyncEnumerable()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(m => m.OneParameterObjectReturnType("")).ReturnsAsync((IEnumerable<object>) null);
+
+			var result = mock.Object.OneParameterObjectReturnType("");
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public void Many_parameters_object_return_type__ReturnsAsync_null__returns_null_AsyncEnumerable()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(m => m.ManyParametersObjectReturnType("", false, 0f)).ReturnsAsync((IEnumerable<object>) null);
+
+			var result = mock.Object.ManyParametersObjectReturnType("", false, 0f);
+
+			Assert.Null(result);
+		}
+#endif
 	}
 }

--- a/tests/Moq.Tests/ReturnsExtensionsFixture.cs
+++ b/tests/Moq.Tests/ReturnsExtensionsFixture.cs
@@ -6,6 +6,11 @@ using System.Threading.Tasks;
 
 using Xunit;
 
+#if FEATURE_ASYNC_ENUMERABLE
+using System.Collections.Generic;
+using System.Linq;
+#endif
+
 namespace Moq.Tests
 {
 	public class ReturnsExtensionsFixture
@@ -57,6 +62,31 @@ namespace Moq.Tests
 
 			ValueTask<object> ManyParametersObjectReturnType(string arg1, bool arg2, float arg3);
 		}
+
+#if FEATURE_ASYNC_ENUMERABLE
+		public interface IAsyncEnumerableAsyncInterface
+		{
+			IAsyncEnumerable<string> NoParametersRefReturnType();
+
+			IAsyncEnumerable<int> NoParametersValueReturnType();
+
+			IAsyncEnumerable<string> RefParameterRefReturnType(string value);
+
+			IAsyncEnumerable<int> RefParameterValueReturnType(string value);
+
+			IAsyncEnumerable<string> ValueParameterRefReturnType(int value);
+
+			IAsyncEnumerable<int> ValueParameterValueReturnType(int value);
+
+			IAsyncEnumerable<Guid> NewGuidAsync();
+
+			IAsyncEnumerable<object> NoParametersObjectReturnType();
+
+			IAsyncEnumerable<object> OneParameterObjectReturnType(string value);
+
+			IAsyncEnumerable<object> ManyParametersObjectReturnType(string arg1, bool arg2, float arg3);
+		}
+#endif
 
 		[Fact]
 		public void ReturnsAsync_on_NoParametersRefReturnType()
@@ -909,6 +939,453 @@ namespace Moq.Tests
 			var paramName = Assert.Throws<ArgumentNullException>(setup).ParamName;
 			Assert.Equal("random", paramName);
 		}
+
+#if FEATURE_ASYNC_ENUMERABLE
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_on_NoParametersRefReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.NoParametersRefReturnType()).ReturnsAsync(new[] { "TestString" });
+
+			var enumerable = mock.Object.NoParametersRefReturnType();
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { "TestString" }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_on_NoParametersValueReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.NoParametersValueReturnType()).ReturnsAsync(new[] { 36 });
+
+			var enumerable = mock.Object.NoParametersValueReturnType();
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { 36 }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_on_RefParameterRefReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.RefParameterRefReturnType("Param1")).ReturnsAsync(new[] { "TestString" });
+
+			var enumerable = mock.Object.RefParameterRefReturnType("Param1");
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { "TestString" }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_on_RefParameterValueReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("Param1")).ReturnsAsync(new[] { 36 });
+
+			var enumerable = mock.Object.RefParameterValueReturnType("Param1");
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { 36 }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_on_ValueParameterRefReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.ValueParameterRefReturnType(36)).ReturnsAsync(new[] { "TestString" });
+
+			var enumerable = mock.Object.ValueParameterRefReturnType(36);
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { "TestString" }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsync_on_ValueParameterValueReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.ValueParameterValueReturnType(36)).ReturnsAsync(new[] { 37 });
+
+			var enumerable = mock.Object.ValueParameterValueReturnType(36);
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { 37 }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsyncFunc_on_NoParametersRefReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.NoParametersRefReturnType()).ReturnsAsync(() => new[] { "TestString" });
+
+			var enumerable = mock.Object.NoParametersRefReturnType();
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { "TestString" }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsyncFunc_on_NoParametersValueReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.NoParametersValueReturnType()).ReturnsAsync(() => new[] { 36 });
+
+			var enumerable = mock.Object.NoParametersValueReturnType();
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { 36 }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsyncFunc_on_RefParameterRefReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.RefParameterRefReturnType("Param1")).ReturnsAsync(() => new[] { "TestString" });
+
+			var enumerable = mock.Object.RefParameterRefReturnType("Param1");
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { "TestString" }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsyncFunc_on_RefParameterValueReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("Param1")).ReturnsAsync(() => new[] { 36 });
+
+			var enumerable = mock.Object.RefParameterValueReturnType("Param1");
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { 36 }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsyncFunc_on_ValueParameterRefReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.ValueParameterRefReturnType(36)).ReturnsAsync(() => new[] { "TestString" });
+
+			var enumerable = mock.Object.ValueParameterRefReturnType(36);
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { "TestString" }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsyncFunc_on_ValueParameterValueReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.ValueParameterValueReturnType(36)).ReturnsAsync(() => new[] { 37 });
+
+			var enumerable = mock.Object.ValueParameterValueReturnType(36);
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(new[] { 37 }, task.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsyncFunc_onEachInvocation_ValueReturnTypeLazyEvaluation()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.NewGuidAsync()).ReturnsAsync(() => new[] { Guid.NewGuid() });
+
+			var firstEnumerable = mock.Object.NewGuidAsync();
+			var secondEnumerable = mock.Object.NewGuidAsync();
+			var firstTask = firstEnumerable.ToArrayAsync();
+			var secondTask = secondEnumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<Guid>>(firstEnumerable);
+			Assert.IsAssignableFrom<IAsyncEnumerable<Guid>>(secondEnumerable);
+			Assert.NotEqual(firstTask.Result, secondTask.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsyncFunc_onEachInvocation_RefReturnTypeLazyEvaluation()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.ValueParameterRefReturnType(36)).ReturnsAsync(() => new[] { new string(new[] { 'M', 'o', 'q', '4' }) });
+
+			var firstEnumerable = mock.Object.ValueParameterRefReturnType(36);
+			var secondEnumerable = mock.Object.ValueParameterRefReturnType(36);
+			var firstTask = firstEnumerable.ToArrayAsync();
+			var secondTask = secondEnumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(firstEnumerable);
+			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(secondEnumerable);
+			Assert.NotEqual(firstTask.Result, secondTask.Result);
+		}
+
+		[Fact]
+		public void AsyncEnumerableThrowsAsync_on_NoParametersRefReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.NoParametersRefReturnType()).ThrowsAsync(exception);
+
+			var enumerable = mock.Object.NoParametersRefReturnType();
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(enumerable);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+
+		[Fact]
+		public void AsyncEnumerableThrowsAsync_on_NoParametersValueReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.NoParametersValueReturnType()).ThrowsAsync(exception);
+
+			var enumerable = mock.Object.NoParametersValueReturnType();
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+
+		[Fact]
+		public void AsyncEnumerableThrowsAsync_on_RefParameterRefReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.RefParameterRefReturnType("Param1")).ThrowsAsync(exception);
+
+			var enumerable = mock.Object.RefParameterRefReturnType("Param1");
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(enumerable);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+
+		[Fact]
+		public void AsyncEnumerableThrowsAsync_on_RefParameterValueReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.RefParameterValueReturnType("Param1")).ThrowsAsync(exception);
+
+			var enumerable = mock.Object.RefParameterValueReturnType("Param1");
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+
+		[Fact]
+		public void AsyncEnumerableThrowsAsync_on_ValueParameterRefReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.ValueParameterRefReturnType(36)).ThrowsAsync(exception);
+
+			var enumerable = mock.Object.ValueParameterRefReturnType(36);
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<string>>(enumerable);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+
+		[Fact]
+		public void AsyncEnumerableThrowsAsync_on_ValueParameterValueReturnType()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.ValueParameterValueReturnType(36)).ThrowsAsync(exception);
+
+			var enumerable = mock.Object.ValueParameterValueReturnType(36);
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsyncWithDelayDoesNotImmediatelyComplete()
+		{
+			var longEnoughForAnyBuildServer = TimeSpan.FromSeconds(5);
+
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("test")).ReturnsAsync(new[] { 5 }, longEnoughForAnyBuildServer);
+
+			var enumerable = mock.Object.RefParameterValueReturnType("test");
+			var task = enumerable.ToArrayAsync();
+
+			Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable);
+			Assert.False(task.IsCompleted);
+		}
+
+		[Theory]
+		[InlineData(-1, true)]
+		[InlineData(0, true)]
+		[InlineData(1, false)]
+		public void AsyncEnumerableDelayMustBePositive(int ticks, bool mustThrow)
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+
+			Action setup = () => mock
+				.Setup(x => x.RefParameterValueReturnType("test"))
+				.ReturnsAsync(new[] { 5 }, TimeSpan.FromTicks(ticks));
+
+			if (mustThrow)
+				Assert.Throws<ArgumentException>(setup);
+			else
+				setup();
+		}
+
+		[Fact]
+		public async Task AsyncEnumerableReturnsAsyncWithDelayReturnsValue()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("test")).ReturnsAsync(new[] { 5 }, TimeSpan.FromMilliseconds(1));
+
+			var task = mock.Object.RefParameterValueReturnType("test");
+			var value = await Assert.IsAssignableFrom<IAsyncEnumerable<int>>(task).ToArrayAsync();
+
+			Assert.Equal(new[] { 5 }, value);
+		}
+
+		[Fact]
+		public async Task AsyncEnumerableReturnsAsyncWithMinAndMaxDelayReturnsValue()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("test")).ReturnsAsync(new[] { 5 }, TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2));
+
+			var enumerable = mock.Object.RefParameterValueReturnType("test");
+			var value = await Assert.IsAssignableFrom<IAsyncEnumerable<int>>(enumerable).ToArrayAsync();
+
+			Assert.Equal(new[] { 5 }, value);
+		}
+
+		[Fact]
+		public async Task AsyncEnumerableReturnsAsyncWithMinAndMaxDelayAndOwnRandomGeneratorReturnsValue()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("test")).ReturnsAsync(new[] { 5 }, TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2), new Random());
+
+			var task = mock.Object.RefParameterValueReturnType("test");
+			var value = await Assert.IsAssignableFrom<IAsyncEnumerable<int>>(task).ToArrayAsync();
+
+			Assert.Equal(new[] { 5 }, value);
+		}
+
+		[Fact]
+		public void AsyncEnumerableReturnsAsyncWithNullRandomGenerator()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+
+			Action setup = () => mock
+				.Setup(x => x.RefParameterValueReturnType("test"))
+				.ReturnsAsync(new[] { 5 }, TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2), null);
+
+			var paramName = Assert.Throws<ArgumentNullException>(setup).ParamName;
+			Assert.Equal("random", paramName);
+		}
+
+		[Fact]
+		public async Task AsyncEnumerableThrowsWithDelay()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+
+			mock
+				.Setup(x => x.RefParameterValueReturnType("test"))
+				.ThrowsAsync(new ArithmeticException("yikes"), TimeSpan.FromMilliseconds(1));
+
+			Func<IAsyncEnumerable<int>> test = () => mock.Object.RefParameterValueReturnType("test");
+
+			var exception = await Assert.ThrowsAsync<ArithmeticException>(() => test().ToArrayAsync().AsTask());
+			Assert.Equal("yikes", exception.Message);
+		}
+
+		[Fact]
+		public async Task AsyncEnumerableThrowsWithRandomDelay()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+
+			var minDelay = TimeSpan.FromMilliseconds(1);
+			var maxDelay = TimeSpan.FromMilliseconds(2);
+
+			mock
+				.Setup(x => x.RefParameterValueReturnType("test"))
+				.ThrowsAsync(new ArithmeticException("yikes"), minDelay, maxDelay);
+
+			Func<IAsyncEnumerable<int>> test = () => mock.Object.RefParameterValueReturnType("test");
+
+			var exception = await Assert.ThrowsAsync<ArithmeticException>(() => test().ToArrayAsync().AsTask());
+			Assert.Equal("yikes", exception.Message);
+		}
+
+		[Fact]
+		public async Task AsyncEnumerableThrowsWithRandomDelayAndOwnRandomGenerator()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+
+			var minDelay = TimeSpan.FromMilliseconds(1);
+			var maxDelay = TimeSpan.FromMilliseconds(2);
+
+			mock
+				.Setup(x => x.RefParameterValueReturnType("test"))
+				.ThrowsAsync(new ArithmeticException("yikes"), minDelay, maxDelay, new Random());
+
+			Func<IAsyncEnumerable<int>> test = () => mock.Object.RefParameterValueReturnType("test");
+
+			var exception = await Assert.ThrowsAsync<ArithmeticException>(() => test().ToArrayAsync().AsTask());
+			Assert.Equal("yikes", exception.Message);
+		}
+
+		[Fact]
+		public void AsyncEnumerableThrowsAsyncWithNullRandomGenerator()
+		{
+			var mock = new Mock<IAsyncEnumerableAsyncInterface>();
+
+			Action setup = () =>
+			{
+				var anyException = new Exception();
+				var minDelay = TimeSpan.FromMilliseconds(1);
+				var maxDelay = TimeSpan.FromMilliseconds(2);
+
+				mock
+					.Setup(x => x.RefParameterValueReturnType("test"))
+					.ThrowsAsync(anyException, minDelay, maxDelay, null);
+			};
+
+			var paramName = Assert.Throws<ArgumentNullException>(setup).ParamName;
+			Assert.Equal("random", paramName);
+		}
+
+
+#endif
 
 		[Fact]
 		public async void No_parameters_object_return_type__ReturnsAsync_null__returns_completed_Task_with_null_result()


### PR DESCRIPTION
This adds `ReturnsAsync` overloads that can return `IAsyncEnumerable<T>` based on an input `IEnumerable<T>` value.

This was first requested in #962.

## Additional information

- Because IAsyncEnumerable is not supported in .NET 4.5, but is supported in .NET Framework 4.6.1 and later, Moq now additionally targets .NET 4.6.1 so that Framework users may also benefit from this feature.
- [System.Linq.Async](https://www.nuget.org/packages/System.Linq.Async) has also been added as an additional dependency.  
    - This could be reduced to just [Microsoft.Bcl.AsyncInterfaces](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/) but would need an implementation of the [ToAsyncEnumerable()](https://github.com/dotnet/reactive/blob/9f2a8090cea4bf931d4ac3ad071f4df147f4df50/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToAsyncEnumerable.cs) extension method.